### PR TITLE
Fixed namespace error in 06-abort.job.php

### DIFF
--- a/large-merchant-services/06-abort.job.php
+++ b/large-merchant-services/06-abort.job.php
@@ -32,6 +32,7 @@ $config = require __DIR__.'/../configuration.php';
  * The namespaces provided by the SDK.
  */
 use \DTS\eBaySDK\Constants;
+use \DTS\eBaySDK\BulkDataExchange\Enums;
 use \DTS\eBaySDK\BulkDataExchange\Services;
 use \DTS\eBaySDK\BulkDataExchange\Types;
 
@@ -63,7 +64,7 @@ if (isset($response->errorMessage)) {
     foreach ($response->errorMessage->error as $error) {
         printf(
             "%s: %s\n\n",
-            $error->severity === BulkDataExchange\Enums\ErrorSeverity::C_ERROR ? 'Error' : 'Warning',
+            $error->severity === Enums\ErrorSeverity::C_ERROR ? 'Error' : 'Warning',
             $error->message
         );
     }


### PR DESCRIPTION
In line 66, `BulkDataExchange\Enums\ErrorSeverity` namespace is used but hasn't been declared above so it throws a class not found exception. I declared the `\DTS\eBaySDK\BulkDataExchange\Enums` namespace and changed the line 66 (now 67) to use the `Enums\ErrorSeverity` namespace.